### PR TITLE
Add Frontiers & Careers, Photonuclear Gordon Conference

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -19,17 +19,17 @@
   eicug: '&#8212;'
   status: 'upcoming'
 
-- name: 'Frontiers &amp; Careers'
-  url: 'https://indico.jlab.org/event/529/'
-  location: 'MIT, Boston, Cambridge'
-  dates: '2022-08-05 to 2022-08-02'
-  eicug: '&#8212;'
-  status: 'upcoming'
-
 - name: 'Photonuclear Gordon Conference'
   url: 'https://www.grc.org/photonuclear-reactions-conference/2022/'
   location: 'Holderness, NH'
   dates: '2022-08-07 to 2022-08-12'
+  eicug: '&#8212;'
+  status: 'upcoming'
+
+- name: 'Frontiers &amp; Careers'
+  url: 'https://indico.jlab.org/event/529/'
+  location: 'MIT, Boston, Cambridge'
+  dates: '2022-08-05 to 2022-08-02'
   eicug: '&#8212;'
   status: 'upcoming'
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -19,6 +19,20 @@
   eicug: '&#8212;'
   status: 'upcoming'
 
+- name: 'Frontiers &amp; Careers'
+  url: 'https://indico.jlab.org/event/529/'
+  location: 'MIT, Boston, Cambridge'
+  dates: '2022-08-05 to 2022-08-02'
+  eicug: '&#8212;'
+  status: 'upcoming'
+
+- name: 'Photonuclear Gordon Conference'
+  url: 'https://www.grc.org/photonuclear-reactions-conference/2022/'
+  location: 'Holderness, NH'
+  dates: '2022-08-07 to 2022-08-12'
+  eicug: '&#8212;'
+  status: 'upcoming'
+
 - name: 'XIVth Quark Confinement and the Hadron Spectrum'
   url: 'https://indico.uis.no/event/2/'
   dates: '2022-08-01 to 2022-08-06'


### PR DESCRIPTION
We don't have a `location` field in the conference data file. Added one to these conferences since just `date` is probably not sufficient.