### PR TITLE
Change site-built time stamp in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -100,7 +100,7 @@
     
     <li class="nav-item">
       <a class="nav-link" style="font-size: xx-small;" href="{{ '/' | relative_url }}">
-      Site built<br/>  {{ site.time }} 
+      Site built: {{ site.time |  date: "%Y-%m-%d %H:%M" }} 
       </a>
     </li>
 


### PR DESCRIPTION
Remove the timezone, which really isn't that useful.
![image](https://user-images.githubusercontent.com/4656391/168333205-9653480c-84c7-4fe2-ac7d-dcc659407599.png)
