### PR TITLE
Calendar page

### DIFF
--- a/_content/cal.md
+++ b/_content/cal.md
@@ -1,0 +1,10 @@
+---
+title: "EICUG Calendar"
+layout: base5
+name: cal
+---
+
+
+## EIC Calendar
+
+The EICUG maintains a [Google calendar](https://calendar.google.com/calendar/u/0/embed?src=eicugadmin@eicug.org&ctz=America/New_York){:target="_blank"} of all EICUG meetings, e.g., the quarterly remote meetings or the hybrid, week-long meetings in the summer. You can view the calendar or subscribe to it via: [https://calendar.google.com/calendar/u/0/embed?src=eicugadmin@eicug.org&ctz=America/New_York](https://calendar.google.com/calendar/u/0/embed?src=eicugadmin@eicug.org&ctz=America/New_York)


### PR DESCRIPTION
It might not be obvious to the EICUG what we intend to do with the calendar: 

-  In the task force, we thought that it would be a good service for the community to provide a calendar of the EICUG meetings that everyone could import in / synchronize with their calendars. 
- Thus, I have created this page. If you find this helpful, we should replace the current link in the main menu with a link to this calendar page.